### PR TITLE
Adding toastr

### DIFF
--- a/source/infinite-scroll.js
+++ b/source/infinite-scroll.js
@@ -1,4 +1,4 @@
-( function ( root, factory )
+( function ( root, factory, toastr )
 {
     if( typeof define === "function" && define.amd )
     {


### PR DESCRIPTION
Line 16, `factory( toastr );` is passing `toastr` as a parameter, but it's undefined at the time.

@jrit 
